### PR TITLE
Add ability to clear filters on favorites page

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -69,6 +69,7 @@
               <p class="tag-hover" data-fav="dip">dip</p>
               <p class="tag-hover" data-fav="spread">spread</p>
             </div>
+            <button class="clear-filters-button">Clear Filters</button>
           </div>
           </aside>
         </div>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -36,6 +36,7 @@ let favDropdownContent = document.querySelector(".dropdown-content-fav-tag");
 const favRecipesTitle = document.querySelector(".fav-recipes-title");
 const thumbnailAside = document.querySelector(".thumbnail-aside-container")
 const favSearchInput = document.querySelector(".fav-search-button-input");
+const clearFilters = document.querySelector(".clear-filters-button");
 
 // EVENT LISTENERS-----------------------------------------------
 window.onload = (event) => {
@@ -61,9 +62,8 @@ window.onload = (event) => {
     displayAllRecipes();
     injectFilterTags();
     recipesList.updateRecipesList();
-    hideElement([aside])
-
-  })
+    hideElement([aside]);
+  });
 };
 
 allRecipes.addEventListener('click', function(e) {
@@ -113,8 +113,8 @@ dropdownContent.addEventListener("click", function(e) {
   if(e.target.classList.contains('tag-hover')) {
     applyFilter(e.target.dataset.id);
     displayFilteredContent();
-    hideElement([aside, allSearchBar, allFilter, allRecipesTitle])
-    showElement([allRecipesButton])
+    hideElement([aside, allSearchBar, allFilter, allRecipesTitle]);
+    showElement([allRecipesButton]);
   };
 });
 
@@ -132,13 +132,13 @@ searchInput.addEventListener("keypress", function(e) {
     event.preventDefault();
     applySearch(`${searchInput.value}`);
     displaySearchedContent();
-    hideElement([aside, allSearchBar, allFilter, allRecipesTitle])
-    showElement([allRecipesButton])
+    hideElement([aside, allSearchBar, allFilter, allRecipesTitle]);
+    showElement([allRecipesButton]);
   };
 });
 
 favoriteRecipesButton.addEventListener("click", function() {
-  hideElement([allRecipesContainer, favoriteRecipesButton, allSearchBar, allFilter]);
+  hideElement([allRecipesContainer, favoriteRecipesButton, allSearchBar, allFilter, recipeDetailsContainer]);
   showElement([favoriteRecipesContainer, allRecipesButton]);
   // favoriteRecipes = new RecipeRepository(currentUser.favoriteRecipes)
   displayFavoriteRecipes();
@@ -159,6 +159,11 @@ favSearchInput.addEventListener("keypress", function(e) {
     displayFavSearchedContent();
   };
 });
+
+clearFilters.addEventListener("click", function() {
+  displayFavoriteRecipes();
+});
+
 // EVENT HANDLERS------------------------------------------------
 const showElement = elements => {
   elements.forEach(element => element.classList.remove('hidden'));


### PR DESCRIPTION
# Description <img src="https://cdn190.picsart.com/232355564004212.png?type=webp&to=crop&r=256" alt="drawing" width="50"/>

Added a button on our favorites page to clear the filters and view all favorites again.

## Issues

Closes #56 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor feature (non-breaking change that modifies existing work)
- [ ] Cosmetic changes (changes to layout or visuals in CSS file)


# How Has This Been Tested?

- [x] console.log()
- [x] dev tools
- [x] functionality check through web browser



# Checklist:

- [x] My code follows the style guidelines of this project (semicolons, indentation, naming conventions, etc..)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have deleted all comments/console.log() after functionality and understanding is final
- [x] I have added any issues closed by this PR in the Issues section.
- [x] I have added others as reviewers
